### PR TITLE
fix(BLOTT-1206): Ensure amounts display with two decimal places

### DIFF
--- a/app/first-step.tsx
+++ b/app/first-step.tsx
@@ -35,8 +35,11 @@ export default function FirstStep() {
       />
       {amount && (
         <Text>
-          You will receive USD {Number.parseFloat(amount).toFixed(2)} tokens in
-          your wallet.
+          You will receive USD {
+            isNaN(Number.parseFloat(amount)) 
+              ? "0.00" 
+              : Number.parseFloat(amount).toFixed(2)
+          } tokens in your wallet.
         </Text>
       )}
     </View>

--- a/app/first-step.tsx
+++ b/app/first-step.tsx
@@ -34,7 +34,10 @@ export default function FirstStep() {
         }}
       />
       {amount && (
-        <Text>You will receive USD {amount} tokens in your wallet.</Text>
+        <Text>
+          You will receive USD {Number.parseFloat(amount).toFixed(2)} tokens in
+          your wallet.
+        </Text>
       )}
     </View>
   );

--- a/app/first-step.tsx
+++ b/app/first-step.tsx
@@ -35,11 +35,11 @@ export default function FirstStep() {
       />
       {amount && (
         <Text>
-          You will receive USD {
-            isNaN(Number.parseFloat(amount)) 
-              ? "0.00" 
-              : Number.parseFloat(amount).toFixed(2)
-          } tokens in your wallet.
+          You will receive USD{" "}
+          {isNaN(Number.parseFloat(amount))
+            ? "0.00"
+            : Number.parseFloat(amount).toFixed(2)}{" "}
+          tokens in your wallet.
         </Text>
       )}
     </View>


### PR DESCRIPTION
## 🔗 Jira Link

[BLOTT-1206](https://spotpaymentsltd.atlassian.net/browse/BLOTT-1206) - Ensure amounts display with two decimal places

## 📋 Problem

When a user inputs "100" in the amount field, it displays as "100" instead of "100.00", creating an inconsistent user experience with decimal formatting expectations for currency/monetary values.

## 🔍 Root Cause

The `FirstStep` component was using simple string interpolation (`{amount}`) to display the amount value directly without any number formatting, unlike standard currency display patterns that require two decimal places.

## ✅ Solution

- Added `Number.parseFloat(amount).toFixed(2)` to ensure all numeric inputs display with exactly two decimal places
- Implemented `isNaN()` validation to handle invalid input gracefully
- Applied proper JSX formatting for better code readability and maintainability

## 🧪 Testing

- [x] Manual testing completed - verified number formatting logic with various inputs
- [x] ESLint validation passed (no linting errors)
- [x] TypeScript compilation passed (no type errors)
- [x] Prettier formatting applied automatically
- [x] No regression issues found - only affects display formatting
- [x] Edge cases considered - handles invalid input with "0.00" fallback
- [x] Follows existing code patterns

## 📝 Changes Made

**File**: `app/first-step.tsx`

- Added number formatting logic using `parseFloat()` and `toFixed(2)`
- Implemented NaN validation for invalid input handling
- Improved JSX formatting and spacing for better readability

## 🎯 Expected Result

**Before**: User inputs "100" → displays "You will receive USD 100 tokens in your wallet."
**After**: User inputs "100" → displays "You will receive USD 100.00 tokens in your wallet."

All amount inputs will now consistently display with 2 decimal places, providing a professional and consistent user experience across the application.